### PR TITLE
Chapter 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -1,0 +1,70 @@
+class MicropostsController < ApplicationController
+  before_action :set_micropost, only: %i[ show edit update destroy ]
+
+  # GET /microposts or /microposts.json
+  def index
+    @microposts = Micropost.all
+  end
+
+  # GET /microposts/1 or /microposts/1.json
+  def show
+  end
+
+  # GET /microposts/new
+  def new
+    @micropost = Micropost.new
+  end
+
+  # GET /microposts/1/edit
+  def edit
+  end
+
+  # POST /microposts or /microposts.json
+  def create
+    @micropost = Micropost.new(micropost_params)
+
+    respond_to do |format|
+      if @micropost.save
+        format.html { redirect_to @micropost, notice: "Micropost was successfully created." }
+        format.json { render :show, status: :created, location: @micropost }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @micropost.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /microposts/1 or /microposts/1.json
+  def update
+    respond_to do |format|
+      if @micropost.update(micropost_params)
+        format.html { redirect_to @micropost, notice: "Micropost was successfully updated." }
+        format.json { render :show, status: :ok, location: @micropost }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @micropost.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /microposts/1 or /microposts/1.json
+  def destroy
+    @micropost.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to microposts_path, status: :see_other, notice: "Micropost was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_micropost
+      @micropost = Micropost.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def micropost_params
+      params.expect(micropost: [ :content, :user_id ])
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,70 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: %i[ show edit update destroy ]
+
+  # GET /users or /users.json
+  def index
+    @users = User.all
+  end
+
+  # GET /users/1 or /users/1.json
+  def show
+  end
+
+  # GET /users/new
+  def new
+    @user = User.new
+  end
+
+  # GET /users/1/edit
+  def edit
+  end
+
+  # POST /users or /users.json
+  def create
+    @user = User.new(user_params)
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to @user, notice: "User was successfully created." }
+        format.json { render :show, status: :created, location: @user }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /users/1 or /users/1.json
+  def update
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, notice: "User was successfully updated." }
+        format.json { render :show, status: :ok, location: @user }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /users/1 or /users/1.json
+  def destroy
+    @user.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to users_path, status: :see_other, notice: "User was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_user
+      @user = User.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def user_params
+      params.expect(user: [ :name, :email ])
+    end
+end

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,0 +1,2 @@
+module MicropostsHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,0 +1,2 @@
+class Micropost < ApplicationRecord
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,3 @@
 class Micropost < ApplicationRecord
+  validates :content, length: { maximum: 140 }
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,3 +1,4 @@
 class Micropost < ApplicationRecord
-  validates :content, length: { maximum: 140 }
+  belongs_to :user
+  validates :content, length: { maximum: 140 }, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,5 @@
 class User < ApplicationRecord
+  has_many :microposts
+  validates :name, presence: true
+  validates :email, presence: true
 end

--- a/app/views/microposts/_form.html.erb
+++ b/app/views/microposts/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: micropost) do |form| %>
+  <% if micropost.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(micropost.errors.count, "error") %> prohibited this micropost from being saved:</h2>
+
+      <ul>
+        <% micropost.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :content, style: "display: block" %>
+    <%= form.textarea :content %>
+  </div>
+
+  <div>
+    <%= form.label :user_id, style: "display: block" %>
+    <%= form.number_field :user_id %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id micropost %>">
+  <p>
+    <strong>Content:</strong>
+    <%= micropost.content %>
+  </p>
+
+  <p>
+    <strong>User:</strong>
+    <%= micropost.user_id %>
+  </p>
+
+</div>

--- a/app/views/microposts/_micropost.json.jbuilder
+++ b/app/views/microposts/_micropost.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! micropost, :id, :content, :user_id, :created_at, :updated_at
+json.url micropost_url(micropost, format: :json)

--- a/app/views/microposts/edit.html.erb
+++ b/app/views/microposts/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Editing micropost" %>
+
+<h1>Editing micropost</h1>
+
+<%= render "form", micropost: @micropost %>
+
+<br>
+
+<div>
+  <%= link_to "Show this micropost", @micropost %> |
+  <%= link_to "Back to microposts", microposts_path %>
+</div>

--- a/app/views/microposts/index.html.erb
+++ b/app/views/microposts/index.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Microposts" %>
+
+<h1>Microposts</h1>
+
+<div id="microposts">
+  <% @microposts.each do |micropost| %>
+    <%= render micropost %>
+    <p>
+      <%= link_to "Show this micropost", micropost %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New micropost", new_micropost_path %>

--- a/app/views/microposts/index.json.jbuilder
+++ b/app/views/microposts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @microposts, partial: "microposts/micropost", as: :micropost

--- a/app/views/microposts/new.html.erb
+++ b/app/views/microposts/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "New micropost" %>
+
+<h1>New micropost</h1>
+
+<%= render "form", micropost: @micropost %>
+
+<br>
+
+<div>
+  <%= link_to "Back to microposts", microposts_path %>
+</div>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @micropost %>
+
+<div>
+  <%= link_to "Edit this micropost", edit_micropost_path(@micropost) %> |
+  <%= link_to "Back to microposts", microposts_path %>
+
+  <%= button_to "Destroy this micropost", @micropost, method: :delete %>
+</div>

--- a/app/views/microposts/show.json.jbuilder
+++ b/app/views/microposts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "microposts/micropost", micropost: @micropost

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: user) do |form| %>
+  <% if user.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+        <% user.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name, style: "display: block" %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :email, style: "display: block" %>
+    <%= form.text_field :email %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id user %>">
+  <p>
+    <strong>Name:</strong>
+    <%= user.name %>
+  </p>
+
+  <p>
+    <strong>Email:</strong>
+    <%= user.email %>
+  </p>
+
+</div>

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! user, :id, :name, :email, :created_at, :updated_at
+json.url user_url(user, format: :json)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Editing user" %>
+
+<h1>Editing user</h1>
+
+<%= render "form", user: @user %>
+
+<br>
+
+<div>
+  <%= link_to "Show this user", @user %> |
+  <%= link_to "Back to users", users_path %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Users" %>
+
+<h1>Users</h1>
+
+<div id="users">
+  <% @users.each do |user| %>
+    <%= render user %>
+    <p>
+      <%= link_to "Show this user", user %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New user", new_user_path %>

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @users, partial: "users/user", as: :user

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "New user" %>
+
+<h1>New user</h1>
+
+<%= render "form", user: @user %>
+
+<br>
+
+<div>
+  <%= link_to "Back to users", users_path %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @user %>
+
+<div>
+  <%= link_to "Edit this user", edit_user_path(@user) %> |
+  <%= link_to "Back to users", users_path %>
+
+  <%= button_to "Destroy this user", @user, method: :delete %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,12 @@
 
 <%= render @user %>
 
+<p>
+  <% @user.microposts.each do |micropost| %>
+<div><%= micropost.id %> <%= micropost.content %></div>
+<% end %>
+</p>
+
 <div>
   <%= link_to "Edit this user", edit_user_path(@user) %> |
   <%= link_to "Back to users", users_path %>

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "users/user", user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :microposts
   resources :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
-  root "application#hello"
+  root "users#index"
 end

--- a/db/migrate/20250407005838_create_users.rb
+++ b/db/migrate/20250407005838_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250407010347_create_microposts.rb
+++ b/db/migrate/20250407010347_create_microposts.rb
@@ -1,0 +1,10 @@
+class CreateMicroposts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :microposts do |t|
+      t.text :content
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_005838) do
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_07_005838) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_010347) do
+  create_table "microposts", force: :cascade do |t|
+    t.text "content"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"

--- a/exercise.md
+++ b/exercise.md
@@ -1,0 +1,23 @@
+## chapter 2
+
+### 2.2.2
+
+図 2.13を参考にしながら、/users/1/editというURLにアクセスしたときの振る舞いについて図を書いてみてください。
+
+```mermaid
+graph TD;
+
+model["Model</br>(user.rb)"];
+view["View</br>(edit.html.erb)"];
+controller["Controller</br>(users_controller.rb)"];
+
+browser --①/users/:id/edit--> router
+router --②edit--> controller
+controller --③set_user--> controller
+controller --④User.find--> model
+model <--⑤--> Database
+model --⑥User.find--> controller
+controller --⑦@user--> view
+view --⑧HTML--> controller
+controller --⑨HTML--> browser
+```

--- a/test/controllers/microposts_controller_test.rb
+++ b/test/controllers/microposts_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class MicropostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @micropost = microposts(:one)
+  end
+
+  test "should get index" do
+    get microposts_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_micropost_url
+    assert_response :success
+  end
+
+  test "should create micropost" do
+    assert_difference("Micropost.count") do
+      post microposts_url, params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+    end
+
+    assert_redirected_to micropost_url(Micropost.last)
+  end
+
+  test "should show micropost" do
+    get micropost_url(@micropost)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_micropost_url(@micropost)
+    assert_response :success
+  end
+
+  test "should update micropost" do
+    patch micropost_url(@micropost), params: { micropost: { content: @micropost.content, user_id: @micropost.user_id } }
+    assert_redirected_to micropost_url(@micropost)
+  end
+
+  test "should destroy micropost" do
+    assert_difference("Micropost.count", -1) do
+      delete micropost_url(@micropost)
+    end
+
+    assert_redirected_to microposts_url
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get index" do
+    get users_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_user_url
+    assert_response :success
+  end
+
+  test "should create user" do
+    assert_difference("User.count") do
+      post users_url, params: { user: { email: @user.email, name: @user.name } }
+    end
+
+    assert_redirected_to user_url(User.last)
+  end
+
+  test "should show user" do
+    get user_url(@user)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_user_url(@user)
+    assert_response :success
+  end
+
+  test "should update user" do
+    patch user_url(@user), params: { user: { email: @user.email, name: @user.name } }
+    assert_redirected_to user_url(@user)
+  end
+
+  test "should destroy user" do
+    assert_difference("User.count", -1) do
+      delete user_url(@user)
+    end
+
+    assert_redirected_to users_url
+  end
+end

--- a/test/fixtures/microposts.yml
+++ b/test/fixtures/microposts.yml
@@ -2,8 +2,8 @@
 
 one:
   content: MyText
-  user_id: 1
+  user: one
 
 two:
   content: MyText
-  user_id: 1
+  user: two

--- a/test/fixtures/microposts.yml
+++ b/test/fixtures/microposts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  user_id: 1
+
+two:
+  content: MyText
+  user_id: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+
+two:
+  name: MyString
+  email: MyString

--- a/test/models/micropost_test.rb
+++ b/test/models/micropost_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MicropostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/microposts_test.rb
+++ b/test/system/microposts_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class MicropostsTest < ApplicationSystemTestCase
+  setup do
+    @micropost = microposts(:one)
+  end
+
+  test "visiting the index" do
+    visit microposts_url
+    assert_selector "h1", text: "Microposts"
+  end
+
+  test "should create micropost" do
+    visit microposts_url
+    click_on "New micropost"
+
+    fill_in "Content", with: @micropost.content
+    fill_in "User", with: @micropost.user_id
+    click_on "Create Micropost"
+
+    assert_text "Micropost was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Micropost" do
+    visit micropost_url(@micropost)
+    click_on "Edit this micropost", match: :first
+
+    fill_in "Content", with: @micropost.content
+    fill_in "User", with: @micropost.user_id
+    click_on "Update Micropost"
+
+    assert_text "Micropost was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Micropost" do
+    visit micropost_url(@micropost)
+    click_on "Destroy this micropost", match: :first
+
+    assert_text "Micropost was successfully destroyed"
+  end
+end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+  end
+
+  test "visiting the index" do
+    visit users_url
+    assert_selector "h1", text: "Users"
+  end
+
+  test "should create user" do
+    visit users_url
+    click_on "New user"
+
+    fill_in "Email", with: @user.email
+    fill_in "Name", with: @user.name
+    click_on "Create User"
+
+    assert_text "User was successfully created"
+    click_on "Back"
+  end
+
+  test "should update User" do
+    visit user_url(@user)
+    click_on "Edit this user", match: :first
+
+    fill_in "Email", with: @user.email
+    fill_in "Name", with: @user.name
+    click_on "Update User"
+
+    assert_text "User was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy User" do
+    visit user_url(@user)
+    click_on "Destroy this user", match: :first
+
+    assert_text "User was successfully destroyed"
+  end
+end


### PR DESCRIPTION
# chapter-2

## 学習内容

### scaffold ジェネレーター

```bash
rails generate scaffold <モデル名> <カラム名>:<型>`
```

model, view, controller, migration, route, test を一式作成

`index`, `show`, `new`, `edit`などのページと、REST API が定義される

```bash
rails db:migrate
```

で DB にマイグレート

### バリデーション

`models/xxx.rb`に記載

| オプション                 | 内容                   |
| :------------------------- | :--------------------- |
| `presence: true`           | 値が空でないか         |
| `uniqueness: true`         | 重複していないか       |
| `length: { ... }`          | 文字列の長さ制限       |
| `format: { with: ... }`    | 正規表現で形式チェック |
| `numericality: true`       | 数字かどうか           |
| `inclusion: { in: [...] }` | 指定した値の中にあるか |
| `exclusion: { in: [...] }` | 指定した値の中にないか |

### 関連付け

`models/xxx.rb`に記載

|種類|内容|
|:--|:--|
|`belongs_to`|属する|
|`has_one`|1:1|
|`has_many`|1:N|
|`has_many :through`|1:N(中間テーブルを介す)|
|`has_and_belongs_to_many`|N:N|

---

## メモ

### `render`

`render "form"`のように文字列で渡すと、テンプレートとして`_form.html.erb`を探す
`render user`のようにオブジェクトを渡すと、`_user.html.erb`を探す

`views/users`で`render micropost`をしたとき、`views/microposts/_micropost.html.erb`が表示される

### %記法

配列・文字列・正規表現などをクォートやカンマなしで書ける

| 記法 | 用途                         | 例                                                         |
| :--- | :--------------------------- | :--------------------------------------------------------- |
| `%w` | 文字列の配列（クォートなし） | `%w[apple orange banana] => ["apple", "orange", "banana"]` |
| `%i` | シンボルの配列               | `%i[id name email] => [:id, :name, :email]`                |
| `%q` | 文字列                       | `%q[Hello world] => 'Hello world'`                         |
| `%Q` | 文字列(式展開・クォートあり) | `%Q[Hello #{name}] => "Hello #{name}"`                     |
| `%r` | 正規表現                     | `%r{.*} => /.*/`                                           |
| `%x` | コマンド                     | `%x[ls -la] => ls la`                                      |

### `before_action`

`before_action :set_user, only: %i[ show edit update destroy ]`
で、`show`, `edit`, `update`, `destroy`の実行前に`set_user`が呼ばれる

**類似のメソッド**
|メソッド|内容|
|:--|:--|
|`before_action`|アクションの前に実行|
|`after_action`|アクションの後に実行|
|`around_action`|アクションの前後で挟む|

**オプション**
|オプション|内容|
|:--|:--|
|`only`|指定したアクションのみ実行|
|`except`|指定したアクション以外実行|
|`if`|指定したメソッドが`true`なら実行|
|`unless`|指定したメソッドが`false`なら実行|

### ERB 出力式

`<%= %>`の場合、Ruby が実行され結果を出力
`<% %>`の場合、Ruby の実行のみ

### fixtures

yml 形式の MiniTest のテストデータ
読み込みは`test/test_helper.rb`の`fixtures: all`

`belongs_to`(関連付け)をしているので、テストデータのユーザー ID が存在しないとエラーになる

```diff
one:
  content: MyText
- user_id: 1
+ user: one
```

のように ID 指定から定義に変更